### PR TITLE
Fix incorrect stop query instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ Your API must provide a way to fetch the following data:
 
 - List the available routes. You can fetch this data by querying `routes.txt`.
 - List the trips for a specified route. You can fetch this data by querying `trips.txt`.
-- List the stops for a specified trip. You can fetch this data by querying `trips.txt` and `shapes.txt`.
+- List the stops for a specified trip and direction. You can fetch this data by querying `trips.txt` and `stop_times.txt`.
 
 ### Extra credit
 


### PR DESCRIPTION
The instructions say to query `trips.txt` and `shapes.txt`.

This is incorrect. The file to query is actually `stop_times.txt`.

You also need to specify `direction_id` to query `stop_times.txt`.

Maybe we should make this query optional?